### PR TITLE
fast fix on Apollo errors

### DIFF
--- a/src/popup/apolloClient.ts
+++ b/src/popup/apolloClient.ts
@@ -1,7 +1,25 @@
 import 'monkeyPatchApollo'
-import {ApolloClient, InMemoryCache} from "@apollo/client/core";
+import {ApolloClient, InMemoryCache,NormalizedCacheObject} from "@apollo/client/core";
 
-export const client = new ApolloClient({
-  uri: 'https://gqlos.plus-sub.com',
-  cache: new InMemoryCache()
-});
+
+class ApolloClientWrapper{
+    private client:ApolloClient<NormalizedCacheObject>|null;
+
+    constructor(){
+      try{
+        this.client= new ApolloClient({
+          uri: 'https://gqlos.plus-sub.com',
+          cache: new InMemoryCache()
+        });
+      }catch(err){
+        console.warn("Can't create ApolloClient",err.message)
+        this.client=null
+      }
+    }
+
+    public getClient(): ApolloClient<NormalizedCacheObject>|null {
+      return this.client;
+    }
+}
+
+export const client = new ApolloClientWrapper()

--- a/src/popup/language/store/listContentLanguagesQuery/index.ts
+++ b/src/popup/language/store/listContentLanguagesQuery/index.ts
@@ -4,8 +4,26 @@ import { client } from '@/apolloClient';
 
 export * from './__gen_gql';
 
+const fallback =  {
+  listContentLanguages: {
+      data:[]
+  }
+}
 export const listContentLanguagesQuery = async (): Promise<ListContentLanguagesQuery> => {
-  return client
-    .query<ListContentLanguagesQuery>({ query })
-    .then((r) => r.data);
+  const _client = client.getClient()
+  if(_client===null){
+    return fallback
+  }else{
+    try{
+      return _client
+      .query<ListContentLanguagesQuery>({ query })
+      .then((r) => r.data).catch((err)=>{
+        console.warn("listContentLanguagesQuery fail(catch): ", err.message)
+        return fallback
+      })
+    }catch(err){
+      console.warn("listContentLanguagesQuery fail: ", err.message)
+      return fallback
+    }
+  }
 };

--- a/src/popup/search/pages/movieTv/searchQuery/index.ts
+++ b/src/popup/search/pages/movieTv/searchQuery/index.ts
@@ -5,12 +5,28 @@ import { client } from '@/apolloClient';
 export * from './__gen_gql';
 
 export const searchQuery = async (variables: VideoSearchQueryVariables): Promise<VideoSearchQuery & {query: string}> => {
-  return client
-    .query<VideoSearchQuery, VideoSearchQueryVariables>({ query, variables })
-    .then((r) => {
-      return {
-        query: variables.query,
-        ...r.data
-      };
-    });
+  const _client = client.getClient()
+  const fallback = {
+    query: variables.query,
+    videoSearch: {
+        entries: []
+    }
+  }
+  if(_client===null){
+    return fallback
+  }else{
+    try{
+      return _client
+      .query<VideoSearchQuery, VideoSearchQueryVariables>({ query, variables })
+      .then((r) => {
+        return {
+          query: variables.query,
+          ...r.data
+        };
+      });
+    }catch(err){
+      console.warn("searchQuery fail: ", err.message)
+      return fallback
+    }
+  }
 };

--- a/src/popup/search/pages/subtitleForMovies/searchQuery/index.ts
+++ b/src/popup/search/pages/subtitleForMovies/searchQuery/index.ts
@@ -3,8 +3,23 @@ import { SubtitleSearchForMoviesQuery, SubtitleSearchForMoviesQueryVariables } f
 export * from './__gen_gql'
 import { client } from '@/apolloClient';
 
+const fallback={
+  subtitleSearch: {
+      data: []
+  }
+}
 export const searchQuery = async (variables: SubtitleSearchForMoviesQueryVariables): Promise<SubtitleSearchForMoviesQuery> => {
-  return client
-    .query<SubtitleSearchForMoviesQuery, SubtitleSearchForMoviesQueryVariables>({ query, variables })
-    .then((r) => r.data);
+  const _client = client.getClient()
+  if(_client===null){
+    return fallback
+  }else{
+    try{
+      return _client
+      .query<SubtitleSearchForMoviesQuery, SubtitleSearchForMoviesQueryVariables>({ query, variables })
+      .then((r) => r.data);
+    }catch(err){
+      console.warn("searchQuery fail: ", err.message)
+      return fallback
+    }
+  }
 };

--- a/src/popup/search/pages/subtitleForSeries/searchQuery/index.ts
+++ b/src/popup/search/pages/subtitleForSeries/searchQuery/index.ts
@@ -4,8 +4,27 @@ import { client } from '@/apolloClient';
 
 export * from './__gen_gql'
 
+const fallback = {
+  subtitleSearch: {
+      data: []
+  },
+  seasons: {
+      seasons: []
+  }
+}
+
 export const searchQuery = async (variables: SubtitleSearchForSeriesQueryVariables): Promise<SubtitleSearchForSeriesQuery> => {
-  return client
-    .query<SubtitleSearchForSeriesQuery, SubtitleSearchForSeriesQueryVariables>({ query, variables })
-    .then((r) => r.data);
+  const _client = client.getClient()
+  if(_client===null){
+    return fallback
+  }else{
+    try{
+      return _client
+      .query<SubtitleSearchForSeriesQuery, SubtitleSearchForSeriesQueryVariables>({ query, variables })
+      .then((r) => r.data);
+    }catch(err){
+      console.warn("searchQuery fail: ", err.message)
+      return fallback
+    }
+  }
 };

--- a/src/popup/track/store/trackMutation/index.ts
+++ b/src/popup/track/store/trackMutation/index.ts
@@ -6,13 +6,33 @@ export interface Payload {
   language: string;
 }
 
+
 export const trackMutation = async ({source, language}: Payload): Promise<unknown> => {
-  return client.mutate({
+  const _client = client.getClient()
+  // probably this fallback maybe is not correct (but seems not to be a problem)
+  const fallback = {
     mutation,
     variables: {
       origin: window.location.origin,
       source,
       language
     }
-  });
+  }
+  if(_client===null){    
+    return fallback
+  }else{
+    try{
+      return _client.mutate({
+        mutation,
+        variables: {
+          origin: window.location.origin,
+          source,
+          language
+        }
+      });
+    }catch(err){
+      console.warn("trackMutation fail: ",err.message)
+      return fallback
+    }
+  }
 };


### PR DESCRIPTION
I just create several try-catch block on all the ApolloClient invokes.

In this way if there is an error with ApolloClient, the extension will still work in "offline-mode", in this way I'm able to upload subtitle and use them.

Is not an elegant solution, but it can be a good starting point.